### PR TITLE
Add HTTP Parameter Pollution module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ app.listen(3000);
   - CRLF Injection
   - Cross-Site-Scripting (XSS)
   - Directory / Path Traversal
+  - HTTP Parameter Pollution
   - Open Redirect / Server Side Request Forgery (SSRF) (queryUrlWhitelist option must be set)
   - Prototype Pollution
   - SQL Injections and NoSQL Injections
@@ -99,6 +100,8 @@ The following table shows which user input is checked by which module:
 \* Bodies are only checked if req.body is set by a middleware or the web framework itself before EasyWAF.  
 \*\* Includes user agent and cookies  
 \*\*\* Only if req.query is set by a framework.
+
+A short description of all modules can be found in [lib/modules](lib/modules).
 
 ## Contact
 If a public GitHub issue or discussion is not the right choice for your concern, you can contact me directly:

--- a/README.md
+++ b/README.md
@@ -82,21 +82,23 @@ app.use(easyWaf({
 
 The following table shows which user input is checked by which module:
 
-| Name                          | URL | Body* | Headers** | IP |
-| ----------------------------- | --- | ----- | ------- | -- |
-| Bad Bots                      | ❌  | ❌   | ✅     | ❌ |
-| Block Tor Exit Nodes          | ❌  | ❌   | ❌     | ✅ |
-| CRLF Injection                | ✅  | ✅   | ❌     | ❌ |
-| Cross-Site-Scripting (XSS)    | ✅  | ✅   | ✅     | ❌ |
-| Directory Traversal           | ✅  | ✅   | ❌     | ❌ |
-| Fake Search Crawlers          | ❌  | ❌   | ✅     | ✅ |
-| NoSQL Injections              | ✅  | ✅   | ✅     | ❌ |
-| Open Redirect / SSRF          | ✅  | ❌   | ❌     | ❌ |
-| Prototype Pollution           | ✅  | ✅   | ✅     | ❌ |
-| SQL Injections                | ✅  | ✅   | ✅     | ❌ |
+| Name                          | URL    | Body* | Headers** | IP |
+| ----------------------------- | ------ | ----- | --------- | -- |
+| Bad Bots                      | ❌     | ❌   | ✅       | ❌ |
+| Block Tor Exit Nodes          | ❌     | ❌   | ❌       | ✅ |
+| CRLF Injection                | ✅     | ✅   | ❌       | ❌ |
+| Cross-Site-Scripting (XSS)    | ✅     | ✅   | ✅       | ❌ |
+| Directory Traversal           | ✅     | ✅   | ❌       | ❌ |
+| Fake Search Crawlers          | ❌     | ❌   | ✅       | ✅ |
+| HTTP Parameter Pollution      | ✅***  | ❌   | ❌       | ❌ |
+| NoSQL Injections              | ✅     | ✅   | ✅       | ❌ |
+| Open Redirect / SSRF          | ✅     | ❌   | ❌       | ❌ |
+| Prototype Pollution           | ✅     | ✅   | ✅       | ❌ |
+| SQL Injections                | ✅     | ✅   | ✅       | ❌ |
 
 \* Bodies are only checked if req.body is set by a middleware or the web framework itself before EasyWAF.  
-\** Includes user agent and cookies
+\*\* Includes user agent and cookies  
+\*\*\* Only if req.query is set by a framework.
 
 ## Contact
 If a public GitHub issue or discussion is not the right choice for your concern, you can contact me directly:

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,6 +137,17 @@ declare module "modules/fakeSearchCrawlers" {
         name: string;
     };
 }
+declare module "modules/httpParameterPollution" {
+    /**
+     *
+     * @param {EasyWAFRequestInfo} data
+     * @returns {Boolean} Is false when a possible security incident has been found
+     */
+    export function check(data: EasyWAFRequestInfo): boolean;
+    export function info(): {
+        name: string;
+    };
+}
 declare module "modules/noSqlInjection" {
     /**
      *
@@ -228,6 +239,12 @@ declare module "modules/index" {
         init: (conf: EasyWafConfig) => void;
         check: (reqInfo: EasyWAFRequestInfo) => Promise<any>;
         updateIPWhitelist: () => void;
+        info: () => {
+            name: string;
+        };
+    };
+    export const httpParameterPollution: {
+        check: (data: EasyWAFRequestInfo) => boolean;
         info: () => {
             name: string;
         };
@@ -328,6 +345,7 @@ type EasyWafConfigModules = {
      * Blocks crawlers that pretend to be a google bot or a bot from other major search engines or internet companies.
      */
     fakeSearchCrawlers?: EasyWafConfigModule;
+    httpParameterPollution?: EasyWafConfigModule;
     noSqlInjection?: EasyWafConfigModule;
     openRedirect?: EasyWafConfigModule;
     prototypePollution?: EasyWafConfigModule;
@@ -375,6 +393,10 @@ type EasyWAFRequestInfo = {
      */
     path: string;
     /**
+     * Parsed url query
+     */
+    query: any;
+    /**
      * User Agent
      */
     ua: string;
@@ -385,3 +407,7 @@ type EasyWAFRequestInfo = {
 };
 type EasyWAFPreBlockHook = (req: import('http').IncomingMessage, moduleInfo: EasyWAFModuleInfo, ip: string) => boolean;
 type EasyWAFPostBlockHook = (req: import('http').IncomingMessage, moduleInfo: EasyWAFModuleInfo, ip: string) => any;
+type EasyWAFExtendIncomingMessage = {
+    body?: any;
+    query?: any;
+};

--- a/lib/easy-waf.js
+++ b/lib/easy-waf.js
@@ -15,13 +15,28 @@ var config = {
     ipWhitelist: [],
     queryUrlWhitelist: undefined,
     modules: {
+        badBots: {
+            enabled: true
+        },
+        blockTorExitNodes: {
+            enabled: false
+        },
+        crlfInjection: {
+            enabled: true
+        },
         directoryTraversal: {
             enabled: true
         },
-        xss: {
+        fakeSearchCrawlers: {
             enabled: true
         },
-        badBots: {
+        httpParameterPollution: {
+            enabled: true,
+        },
+        noSqlInjection: {
+            enabled: true
+        },
+        openRedirect: {
             enabled: true
         },
         prototypePollution: {
@@ -30,21 +45,9 @@ var config = {
         sqlInjection: {
             enabled: true
         },
-        noSqlInjection: {
+        xss: {
             enabled: true
         },
-        crlfInjection: {
-            enabled: true
-        },
-        blockTorExitNodes: {
-            enabled: false
-        },
-        openRedirect: {
-            enabled: true
-        },
-        fakeSearchCrawlers: {
-            enabled: true
-        }
     },
     postBlockHook: undefined,
     preBlockHook: undefined,
@@ -109,12 +112,12 @@ function easyWaf(conf){
     }
 
     return async function EasyWaf(
-        /** @type {import('http').IncomingMessage} */ req,
+        /** @type {import('http').IncomingMessage & EasyWAFExtendIncomingMessage} */ req,
         /** @type {import('http').ServerResponse} **/ res,
         /** @type {CallableFunction} **/ next){
 
         /** @type {String} */
-        var ip = proxyaddr(req, trustProxy);
+        const ip = proxyaddr(req, trustProxy);
 
         if(typeof ip === 'undefined'){
             /* istanbul ignore next */
@@ -138,8 +141,9 @@ function easyWaf(conf){
             }
         }
 
+        let url = '';
         try {
-            var url = decodeURIComponent(req.url);
+            url = decodeURIComponent(req.url);
         } catch(e) {
             if(!block(req, res, {name: 'uriMalformed'}, config, ip)){
                 next();
@@ -148,30 +152,24 @@ function easyWaf(conf){
         }
 
         /** @type {EasyWAFRequestInfo} */
-        var reqInfo = {
-            url: url,
-            ip: ip,
-            path: url.match('^[^?]*')[0],
+        const reqInfo = {
             body: undefined,
-            ua: req.headers['user-agent'] || '',
+            headers: Object.values(req.headers).join(),
+            ip,
             method: req.method,
-            headers: Object.values(req.headers).join()
+            path: url.match('^[^?]*')[0],
+            query: (typeof req.query === 'object' ? req.query : {}),
+            ua: req.headers['user-agent'] || '',
+            url,
         };
 
-        //@ts-ignore
         if(typeof req.body !== 'undefined'){
-            //@ts-ignore
             if(typeof req.body === 'object' && Object.keys(req.body).length){
-                //@ts-ignore
                 reqInfo.body = JSON.stringify(req.body);
-                //@ts-ignore
             } else if(typeof req.body === 'string'){
-                //@ts-ignore
                 reqInfo.body = req.body;
             }
         }
-
-        //modulesLoop(modules, Object.keys(modules), 0, req, res, reqInfo, next);
 
         for (const [key, module] of Object.entries(modules)) {
             if(('enabled' in config.modules[key] && !config.modules[key].enabled) || (config.modules[key].excludePaths instanceof RegExp && config.modules[key].excludePaths.test(reqInfo.path))){

--- a/lib/modules/README.md
+++ b/lib/modules/README.md
@@ -1,0 +1,48 @@
+# Modules
+
+## Bad Bots
+Detects "bad bots" based on the user agent and blocks them.  
+List source (minor changes): [mitchellkrogza/nginx-ultimate-bad-bot-blocker](https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker)
+
+## Block Tor Exit Nodes
+*Disabled by default. Activate by setting modules.blockTorExitNodes.enabled = true*
+
+Blocks all requests originating from tor browser exit nodes. The ip addresses are downloaded from https://check.torproject.org/torbulkexitlist and updated hourly.
+
+## CRLF Injection
+This module blocks HTTP header injections with carriage returns and linefeed characters.  
+[OSWAP: CRLF Injection](https://owasp.org/www-community/vulnerabilities/CRLF_Injection)
+
+## Directory / Path Traversal
+This module detects and blocks path traversal attacks. This vulnerability allows an attacker to read arbitrary files on the server that is running an application.  
+[OSWAP: Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
+
+## Fake Search Crawlers
+This module blocks requests from bots that pretend to be a known search engine or similar. A up to date whitelist with IPS from Google, Bing and DuckDuckGo is used for this purpose. For other providers, the authenticity is checked by doing a reverse DNS lookup and the ip is then temporarily whitelisted.
+
+Whitelist sources: [Google](https://www.gstatic.com/ipranges/goog.json), [Bing](https://www.bing.com/toolbox/bingbot.json), [DuckDuckGo](https://raw.githubusercontent.com/duckduckgo/duckduckgo-help-pages/master/_docs/results/duckduckbot.md)  
+Supported companies: Google, Microsoft, DuckDuckGo, Yahoo!, Yandex, Baidu, Qwant
+
+## HTTP Parameter Pollution
+*Request is not blocked or logged, req.query must be set by a web framework*
+
+Replaces array parameters with their last value, like [hpp](https://www.npmjs.com/package/hpp).  
+[OSWAP: Testing for HTTP Parameter Pollution](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution)
+
+## NoSQL Injection
+NoSQL injections are attacks that aim to modify a database query to a non-relational database, for example to bypass authentication. This module tries to prevent these attacks.  
+[Patrick Spiegel: NoSQL Injection - Fun with Objects and Arrays](https://owasp.org/www-pdf-archive/GOD16-NOSQL.pdf)
+
+## Open Redirect
+*The `queryUrlWhitelist` option must be set to enable this module.*
+
+Blocks requests that have a disallowed url in their path or query.  
+[Snyk Learn: Open redirect](https://learn.snyk.io/lessons/open-redirect/javascript/)
+
+## Prototype Pollution
+A JavaScript vulnerability that allows an attacker to add properties to global object prototypes that can then be inherited by other objects. This module attempts to block such requests.  
+[Snyk Learn: Prototype pollution](https://learn.snyk.io/lessons/prototype-pollution/javascript/)
+
+## SQL Injection
+An attempt to manipulate an SQL query, similar to NoSQL injections. Detection leads to blocking of the request.  
+[OSWAP: SQL Injection](https://owasp.org/www-community/attacks/SQL_Injection)

--- a/lib/modules/httpParameterPollution.js
+++ b/lib/modules/httpParameterPollution.js
@@ -1,0 +1,23 @@
+/**
+ * 
+ * @param {EasyWAFRequestInfo} data
+ * @returns {Boolean} Is false when a possible security incident has been found
+ */
+function check(data){    
+    for (const [, value] of Object.entries(data.query)) {
+        if(Array.isArray(value)){
+            return false;
+        }
+      }
+
+    return true;
+}
+
+module.exports = {
+    check: check,
+    info: () => {
+        return {
+            name: 'httpParameterPollution'
+        };
+    }
+};

--- a/lib/modules/httpParameterPollution.js
+++ b/lib/modules/httpParameterPollution.js
@@ -3,10 +3,10 @@
  * @param {EasyWAFRequestInfo} data
  * @returns {Boolean} Is false when a possible security incident has been found
  */
-function check(data){    
-    for (const [, value] of Object.entries(data.query)) {
+function check(data){
+    for (const [key, value] of Object.entries(data.query)) {
         if(Array.isArray(value)){
-            return false;
+            data.query[key] = value[value.length-1];
         }
       }
 
@@ -15,7 +15,7 @@ function check(data){
 
 module.exports = {
     check: check,
-    info: () => {
+    info: () => { /* istanbul ignore next */
         return {
             name: 'httpParameterPollution'
         };

--- a/lib/modules/index.js
+++ b/lib/modules/index.js
@@ -4,6 +4,7 @@ module.exports = {
     crlfInjection: require('./crlfInjection'),
     directoryTraversal: require('./directoryTraversal'),
     fakeSearchCrawlers: require('./fakeSearchCrawlers'),
+    httpParameterPollution: require('./httpParameterPollution'),
     noSqlInjection: require('./noSqlInjection'),
     openRedirect: require('./openRedirect'),
     prototypePollution: require('./prototypePollution'),

--- a/lib/typedef.js
+++ b/lib/typedef.js
@@ -23,6 +23,7 @@
 * @property {EasyWafConfigModule} [crlfInjection]
 * @property {EasyWafConfigModule} [directoryTraversal]
 * @property {EasyWafConfigModule} [fakeSearchCrawlers] Blocks crawlers that pretend to be a google bot or a bot from other major search engines or internet companies.
+* @property {EasyWafConfigModule} [httpParameterPollution]
 * @property {EasyWafConfigModule} [noSqlInjection]
 * @property {EasyWafConfigModule} [openRedirect]
 * @property {EasyWafConfigModule} [prototypePollution]
@@ -61,6 +62,7 @@
 * @property {String} ip
 * @property {String} method HTTP method (POST/GET...)
 * @property {String} path Url path without query or fragments
+* @property {Object} query Parsed url query
 * @property {String} ua User Agent
 * @property {String} url Decoded url
 */
@@ -78,4 +80,11 @@
 * @param {import('http').IncomingMessage} req
 * @param {EasyWAFModuleInfo} moduleInfo
 * @param {String} ip
+*/
+
+/**
+* @typedef {Object} EasyWAFExtendIncomingMessage
+* 
+* @property {Object} [body]
+* @property {Object} [query]
 */

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --coverage --collectCoverageFrom=lib/**/*.js",
+    "test-server": "node test/test-server",
     "lint": "eslint .",
     "precommit": "tsc && eslint .",
     "prepare": "git config core.hooksPath .git_hooks"

--- a/test/allow/urls.txt
+++ b/test/allow/urls.txt
@@ -9,3 +9,4 @@
 /manifest.json
 /prototype/test.txt
 /test?g=Object.prototypetest
+/test?data=test&data2=test2

--- a/test/block/httpParameterPollution.txt
+++ b/test/block/httpParameterPollution.txt
@@ -1,0 +1,3 @@
+!URL
+18&t=5&a=abc&t=9&b=6
+abc&test[]=6

--- a/test/block/httpParameterPollution.txt
+++ b/test/block/httpParameterPollution.txt
@@ -1,3 +1,0 @@
-!URL
-18&t=5&a=abc&t=9&b=6
-abc&test[]=6

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -86,7 +86,7 @@ describe('Module options', function() {
 describe('Open Redirect', function() {
     test('Allow github.com', () => {
         return request(testServer.app)
-            .get('/get?q=https://github.com/test&q=5')
+            .get('/get?q=https://github.com/test&t=5')
             .then(response => {
                 expect(response.statusCode).toBe(200);
         });

--- a/test/fakeSearchCrawlers3.test.js
+++ b/test/fakeSearchCrawlers3.test.js
@@ -14,7 +14,7 @@ testServer.init({
     },
 });
 
-describe('Fake Googlebot', function () {
+describe('Fake Googlebot', () => {
     test('Request should be blocked', () => {
         return request(testServer.app)
             .get('/get')

--- a/test/httpParameterPollution.test.js
+++ b/test/httpParameterPollution.test.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const easyWaf = require('../index');
+const app = express();
+const request = require('supertest');
+
+jest.useFakeTimers();
+
+app.use(easyWaf({
+    disableLogging: true,
+}));
+
+app.get('/get', function (req, res) {
+    res.status(200).send(req.query);
+});
+
+describe('HTTP Parameter Pollution', () => {
+    test('Remove polluted parameter', () => {
+        return request(app)
+            .get('/get?q=5&a=8&q=6')
+            .then(response => {
+                expect(response.statusCode).toBe(200);
+                expect(response.body).toStrictEqual({'a': '8', 'q': '6'});
+        });
+    });
+    test('Remove two polluted parameters', () => {
+        return request(app)
+            .get('/get?q=5&a=8&g=test&q=6&g=abc&t=7')
+            .then(response => {
+                expect(response.statusCode).toBe(200);
+                expect(response.body).toStrictEqual({'a': '8', 'g': 'abc', 'q': '6', 't': '7'});
+        });
+    });
+});


### PR DESCRIPTION
*Request is not blocked or logged, req.query must be set by a web framework*

Replaces array parameters with their last value, like [hpp](https://www.npmjs.com/package/hpp).  
[OSWAP: Testing for HTTP Parameter Pollution](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution)